### PR TITLE
New TigerSnatch link on course card hover

### DIFF
--- a/course_selection/static/js/models/Course.ts
+++ b/course_selection/static/js/models/Course.ts
@@ -9,6 +9,7 @@ import Section = require('../models/Section');
 class Course implements ICourse {
     private static EASYPCE_BASE_URL: string = "http://easypce.com/courses/";
     private static REGISTRAR_BASE_URL: string = "https://registrar.princeton.edu/course-offerings/course_details.xml?";
+    private static TIGERSNATCH_BASE_URL: string = "https://snatch.tigerapps.org/course?";
     private static REGISTRAR_ID_DIGITS: number = 6;
 
     public title: string;
@@ -26,7 +27,7 @@ class Course implements ICourse {
     public rating: number;
     public easypce_link: string;
     public registrar_link: string;
-    public evaluation_link: string;
+    public snatch_link: string;
 
     constructor(title, description, course_listings,
             id, registrar_id, sections, semester, enrolled?: boolean) {
@@ -50,7 +51,7 @@ class Course implements ICourse {
         this.enrolled = enrolled ? enrolled : false;
         this.easypce_link = Course.EASYPCE_BASE_URL + this.primary_listing;
         this.registrar_link = this.getRegistrarLink();
-        this.evaluation_link = this.getEvaluationLink();
+        this.snatch_link = this.getSnatchLink();
     }
 
     private getRegistrarLink(): string {
@@ -58,11 +59,9 @@ class Course implements ICourse {
             + this.registrar_id + "&term=" + this.semester.term_code;
     }
 
-    private getEvaluationLink(): string {
-        return 'course_evaluations/'
-            + this.semester.term_code 
-            + '/' 
-            + this.registrar_id;
+    private getSnatchLink(): string {
+        return Course.TIGERSNATCH_BASE_URL + "courseid="
+            + this.registrar_id + "&skip";
     }
 
     private getSections(input): Array<ISection> {

--- a/course_selection/static/less/course-search.css
+++ b/course_selection/static/less/course-search.css
@@ -243,7 +243,7 @@
   color: white;
   cursor: pointer;
 }
-.eval-tag {
+.snatch-tag {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -253,7 +253,7 @@
   background-color: orange;
   z-index: 10;
 }
-.eval-tag i {
+.snatch-tag i {
   top: 25%;
   width: 100%;
   position: absolute;

--- a/course_selection/static/less/course-search.less
+++ b/course_selection/static/less/course-search.less
@@ -215,7 +215,7 @@
     z-index: 10;
 }
 
-.eval-tag {
+.snatch-tag {
     .third-rightmost-tag();
     background-color: orange;
     z-index: 10;

--- a/course_selection/static/less/main.css
+++ b/course_selection/static/less/main.css
@@ -472,7 +472,7 @@ body {
   color: white;
   cursor: pointer;
 }
-.eval-tag {
+.snatch-tag {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -482,7 +482,7 @@ body {
   background-color: orange;
   z-index: 10;
 }
-.eval-tag i {
+.snatch-tag i {
   top: 25%;
   width: 100%;
   position: absolute;

--- a/course_selection/templates/main/course-search.html
+++ b/course_selection/templates/main/course-search.html
@@ -26,10 +26,10 @@
                                   ng-bind="course.title"></div>
                          </div>
                          <div ng-show="showTags">
-                             <a class="eval-tag"
+                             <a class="snatch-tag"
                                 target="_blank"
-                                ng-href="{{ course.evaluation_link }}"
-                                ><i class="fa fa-bar-chart-o"
+                                ng-href="{{ course.snatch_link }}"
+                                ><i class="fa fa-clock-o"
                                     ></i></a>
 
                              <a class="more-info-tag"
@@ -88,10 +88,10 @@
                              </div>
                          </div>
                          <div ng-show="showTags">
-                             <a class="eval-tag"
+                             <a class="snatch-tag"
                                 target="_blank"
-                                ng-href="{{ course.evaluation_link }}"
-                                ><i class="fa fa-bar-chart-o"
+                                ng-href="{{ course.snatch_link }}"
+                                ><i class="fa fa-clock-o"
                                     ></i></a>
 
                              <a class="more-info-tag"
@@ -127,10 +127,10 @@
                              </div>
                          </div>
                          <div ng-show="showTags">
-                             <a class="eval-tag"
+                             <a class="snatch-tag"
                                   target="_blank"
-                                  ng-href="{{ course.evaluation_link }}"
-                                 ><i class="fa fa-bar-chart-o"
+                                  ng-href="{{ course.snatch_link }}"
+                                 ><i class="fa fa-clock-o"
                                      ></i></a>
                              <a class="more-info-tag"
                                   target="_blank"


### PR DESCRIPTION
Replaced (broken) course evaluation link with TigerSnatch link. Will add PrincetonCourses link in future PR. Example:
<img width="373" alt="Screen Shot 2021-06-28 at 1 26 21 PM" src="https://user-images.githubusercontent.com/13815069/123699815-878c5a80-d814-11eb-99d9-b9f91e076a18.png">

Demo:
https://user-images.githubusercontent.com/13815069/123699837-8ce9a500-d814-11eb-9c49-59126aca1213.mov