### PR TITLE
Add PrincetonCourses quick link

### DIFF
--- a/course_selection/static/js/models/Course.ts
+++ b/course_selection/static/js/models/Course.ts
@@ -9,6 +9,7 @@ import Section = require('../models/Section');
 class Course implements ICourse {
     private static EASYPCE_BASE_URL: string = "http://easypce.com/courses/";
     private static REGISTRAR_BASE_URL: string = "https://registrar.princeton.edu/course-offerings/course_details.xml?";
+    private static COURSES_BASE_URL: string = "https://www.princetoncourses.com/course/"
     private static TIGERSNATCH_BASE_URL: string = "https://snatch.tigerapps.org/course?";
     private static REGISTRAR_ID_DIGITS: number = 6;
 
@@ -27,6 +28,7 @@ class Course implements ICourse {
     public rating: number;
     public easypce_link: string;
     public registrar_link: string;
+    public courses_link: string;
     public snatch_link: string;
 
     constructor(title, description, course_listings,
@@ -51,12 +53,18 @@ class Course implements ICourse {
         this.enrolled = enrolled ? enrolled : false;
         this.easypce_link = Course.EASYPCE_BASE_URL + this.primary_listing;
         this.registrar_link = this.getRegistrarLink();
+        this.courses_link = this.getCoursesLink();
         this.snatch_link = this.getSnatchLink();
     }
 
     private getRegistrarLink(): string {
         return Course.REGISTRAR_BASE_URL + "courseid=" 
             + this.registrar_id + "&term=" + this.semester.term_code;
+    }
+
+    private getCoursesLink(): string {
+        return Course.COURSES_BASE_URL + this.semester.term_code
+            + this.registrar_id;
     }
 
     private getSnatchLink(): string {

--- a/course_selection/static/less/course-search.css
+++ b/course_selection/static/less/course-search.css
@@ -18,7 +18,7 @@
 .course-panel-title {
   text-align: left;
   padding-left: 2px;
-  width: 70%;
+  width: 60%;
 }
 .course-panels-container {
   position: relative;
@@ -243,13 +243,32 @@
   color: white;
   cursor: pointer;
 }
-.snatch-tag {
+.courses-tag {
   cursor: pointer;
   position: absolute;
   top: 0;
   height: 100%;
   width: 10%;
   right: 20%;
+  background-color: cornflowerblue;
+  z-index: 10;
+}
+.courses-tag i {
+  top: 25%;
+  width: 100%;
+  position: absolute;
+  text-align: center;
+  font-size: 15px;
+  color: white;
+  cursor: pointer;
+}
+.snatch-tag {
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 10%;
+  right: 30%;
   background-color: orange;
   z-index: 10;
 }

--- a/course_selection/static/less/course-search.less
+++ b/course_selection/static/less/course-search.less
@@ -40,7 +40,7 @@
 .course-panel-title {
     text-align: left;
     padding-left: 2px;
-    width: 100% - 3 * @tag-width;
+    width: 100% - 4 * @tag-width;
 }
 
 .course-panels-container {
@@ -204,6 +204,10 @@
     .absolute-tag();
     right: 2 * @tag-width;
 }
+.fourth-rightmost-tag {
+    .absolute-tag();
+    right: 3 * @tag-width;
+}
 .add-tag {
     .rightmost-tag();
     background-color: green;
@@ -215,8 +219,13 @@
     z-index: 10;
 }
 
-.snatch-tag {
+.courses-tag {
     .third-rightmost-tag();
+    background-color: cornflowerblue;
+    z-index: 10;
+}
+.snatch-tag {
+    .fourth-rightmost-tag();
     background-color: orange;
     z-index: 10;
 }

--- a/course_selection/static/less/main.css
+++ b/course_selection/static/less/main.css
@@ -247,7 +247,7 @@ body {
 .course-panel-title {
   text-align: left;
   padding-left: 2px;
-  width: 70%;
+  width: 60%;
 }
 .course-panels-container {
   position: relative;
@@ -472,13 +472,32 @@ body {
   color: white;
   cursor: pointer;
 }
-.snatch-tag {
+.courses-tag {
   cursor: pointer;
   position: absolute;
   top: 0;
   height: 100%;
   width: 10%;
   right: 20%;
+  background-color: cornflowerblue;
+  z-index: 10;
+}
+.courses-tag i {
+  top: 25%;
+  width: 100%;
+  position: absolute;
+  text-align: center;
+  font-size: 15px;
+  color: white;
+  cursor: pointer;
+}
+.snatch-tag {
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 10%;
+  right: 30%;
   background-color: orange;
   z-index: 10;
 }

--- a/course_selection/templates/main/course-search.html
+++ b/course_selection/templates/main/course-search.html
@@ -31,7 +31,11 @@
                                 ng-href="{{ course.snatch_link }}"
                                 ><i class="fa fa-clock-o"
                                     ></i></a>
-
+                             <a class="courses-tag"
+                                target="_blank"
+                                ng-href="{{ course.courses_link }}"
+                                ><i class="fa fa-book"
+                                    ></i></a>
                              <a class="more-info-tag"
                                   target="_blank"
                                   ng-href="{{ course.registrar_link }}"
@@ -93,7 +97,11 @@
                                 ng-href="{{ course.snatch_link }}"
                                 ><i class="fa fa-clock-o"
                                     ></i></a>
-
+                             <a class="courses-tag"
+                                target="_blank"
+                                ng-href="{{ course.courses_link }}"
+                                ><i class="fa fa-book"
+                                    ></i></a>
                              <a class="more-info-tag"
                                   target="_blank"
                                   ng-href="{{ course.registrar_link }}"
@@ -131,6 +139,11 @@
                                   target="_blank"
                                   ng-href="{{ course.snatch_link }}"
                                  ><i class="fa fa-clock-o"
+                                     ></i></a>
+                             <a class="courses-tag"
+                                  target="_blank"
+                                  ng-href="{{ course.courses_link }}"
+                                 ><i class="fa fa-book"
                                      ></i></a>
                              <a class="more-info-tag"
                                   target="_blank"


### PR DESCRIPTION
Added quick link to PrincetonCourses on course card hover. Moved TigerSnatch quick link to the left and adjusted CSS accordingly. Verify that new PrincetonCourses link works and TigerSnatch link did not break:


https://user-images.githubusercontent.com/13815069/123875275-394b8a00-d8ee-11eb-928b-d9f1f47b3cc0.mov

