### PR TITLE
Fix (frequent) recurring server error

### DIFF
--- a/course_selection/views.py
+++ b/course_selection/views.py
@@ -393,7 +393,10 @@ def ical_feed(request, cal_id):
         # course = Course.objects.get(Q(id=course_obj['course_id'])) #
         # course_obj is json object; course is model
         for section_id in course_obj['sections']:
-            section = Section.objects.get(Q(pk=section_id))
+            try:
+                section = Section.objects.get(Q(pk=section_id))
+            except:
+                continue
             for meeting in section.meetings.all():
                 event = Event()
                 event.add('summary', unicode(section))  # name of the event


### PR DESCRIPTION
This error has been repeatedly occurring every <30 seconds:

```
2021-11-14T16:24:24.381161+00:00 app[web.2]: ERROR Internal Server Error: /ical/3605ffc0-83c5-42ba-a2d1-cf8b1b425ac2.ics
2021-11-14T16:24:24.381170+00:00 app[web.2]: Traceback (most recent call last):
2021-11-14T16:24:24.381171+00:00 app[web.2]: File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
2021-11-14T16:24:24.381171+00:00 app[web.2]: response = wrapped_callback(request, *callback_args, **callback_kwargs)
2021-11-14T16:24:24.381176+00:00 app[web.2]: File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/http.py", line 45, in inner
2021-11-14T16:24:24.381176+00:00 app[web.2]: return func(request, *args, **kwargs)
2021-11-14T16:24:24.381176+00:00 app[web.2]: File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
2021-11-14T16:24:24.381177+00:00 app[web.2]: response = view_func(request, *args, **kwargs)
2021-11-14T16:24:24.381177+00:00 app[web.2]: File "/app/course_selection/views.py", line 396, in ical_feed
2021-11-14T16:24:24.381178+00:00 app[web.2]: section = Section.objects.get(Q(pk=section_id))
2021-11-14T16:24:24.381178+00:00 app[web.2]: File "/app/.heroku/python/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
2021-11-14T16:24:24.381178+00:00 app[web.2]: return getattr(self.get_queryset(), name)(*args, **kwargs)
2021-11-14T16:24:24.381178+00:00 app[web.2]: File "/app/.heroku/python/lib/python2.7/site-packages/django/db/models/query.py", line 334, in get
2021-11-14T16:24:24.381179+00:00 app[web.2]: self.model._meta.object_name
2021-11-14T16:24:24.381179+00:00 app[web.2]: DoesNotExist: Section matching query does not exist.
```

It's being caused by a failed `Section` query in `/app/course_selection/views.py`, line 306. Wrapping the query in a `try/except` should resolve the issue and make the error logs and Heroku monitoring panel look much less scary.