### PR TITLE
Update ReCal for Fall '23 course selection

### DIFF
--- a/course_selection/templates/landing/about.html
+++ b/course_selection/templates/landing/about.html
@@ -131,19 +131,6 @@
 
     <div id="about_content">
         <div id="about_container" class="container mtb">
-
-            <div class="row centered">
-                <div class="col-lg-5 col-lg-offset-1">
-                    <h3>Learn more about ReCal</h3>
-                    <p><a href="http://dailyprincetonian.com/news/2015/04/tigerhub-and-recal-take-the-spotlight-during-course-selection/" class="btn btn-theme">Read Daily Princetonian article &rarr;</a></p>
-                </div>
-                <div class="col-lg-5">
-
-                    <h3>What's new in ReCal?</h3>
-                    <p><a href="/status" class="btn btn-theme">Read new features status page &rarr;</a></p>
-                </div>
-            </div> <!-- row -->
-            <br>
             <h3 class="centered">Meet The Team</h3>
             <div class="row">
                 <div class="col-md-4">

--- a/course_selection/templates/landing/index.html
+++ b/course_selection/templates/landing/index.html
@@ -6,11 +6,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Pick your Princeton Spring 2022 courses on ReCal.">
+    <meta name="description" content="Pick your Princeton courses on ReCal.">
     <meta name="author" content="ReCal">
     <meta name="apple-itunes-app" content="app-id=946948041, app-argument=recalCourseSelection://launch">
 
-    <title>Spring 2022 Course Selection | ReCal</title>
+    <title>Course Selection | ReCal</title>
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="{% static 'landing/css/bootstrap.css' %}">

--- a/course_selection/templates/main/header.html
+++ b/course_selection/templates/main/header.html
@@ -14,9 +14,6 @@
         </ul>
     </div>
     <div class="header-item pull-right">
-        <a target="__blank" href="/status">ReCal Status</a>
-    </div>
-    <div class="header-item pull-right">
         <a target="__blank" href="/about">About ReCal</a>
     </div>
     <!-- <div id="updates" class="pull-left">

--- a/course_selection/templates/main/semester-tabs.html
+++ b/course_selection/templates/main/semester-tabs.html
@@ -1,12 +1,6 @@
 {% load staticfiles %}
 {% verbatim %}
 <div id="wrap">
-    <div class="container" style="position: fixed; width: 25%; z-index: 1000; bottom: 100px; left: 20px; margin-bottom: 10px">
-        <div class="alert alert-success alert-dismissible" role="alert">
-             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-             <b>Spring 2022 Courses Updated!</b> We have added the Spring 2022 courses to ReCal. Thank you for your patience.
-         </div>
-    </div>
     <div ng-controller="SemCtrl as semCtrl" id="semesterContainer">
         <tabset>
         <tab ng-repeat = "semester in semesters"

--- a/settings/common.py
+++ b/settings/common.py
@@ -192,9 +192,9 @@ STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 # Similarly, the Spring 2017 term is 1174 - the ending year is 2017.
 # Note: generally, limit this to three terms. This defines the terms that are
 #   scraped and the default terms displayed on schedules.
-ACTIVE_TERMS = [1214, 1222, 1224]
+ACTIVE_TERMS = [1222, 1224, 1232]
 
 # TODO: is this still used? if not, we can remove it
 # Use helper method nice.models.get_cur_semester() to get current Semester
 # object.
-CURR_TERM = 1224
+CURR_TERM = 1232


### PR DESCRIPTION
## Changelog

* Updated `ACTIVE_TERMS` and `CURR_TERM` in `settings/common.py` with the new term code 1232
* Removed term-specific wording across the app (e.g. site title, info modal) to simplify the update process from term to term (now, all that is needed is the previous bullet point)
* Removed links to the Status timeline page from the navbar and the about page (the Status page is useless)

ReCal will self-update tonight at 2 or 3am ET if this PR is merged today.