### PR TITLE
Add announcement for alternate schedule deprecation

### DIFF
--- a/course_selection/static/announcements/css/style.css
+++ b/course_selection/static/announcements/css/style.css
@@ -459,3 +459,10 @@ csmall2 {
 	padding-right: 15px;
 	font-size: 18px;
 }
+
+#announcement-banner {
+	font-weight: bold;
+    font-size: 1.1em;
+    margin-bottom: 0;
+    padding: 10px 15px;
+}

--- a/course_selection/static/announcements/css/style.css
+++ b/course_selection/static/announcements/css/style.css
@@ -459,10 +459,3 @@ csmall2 {
 	padding-right: 15px;
 	font-size: 18px;
 }
-
-#announcement-banner {
-	font-weight: bold;
-    font-size: 1.1em;
-    margin-bottom: 0;
-    padding: 10px 15px;
-}

--- a/course_selection/static/less/main.css
+++ b/course_selection/static/less/main.css
@@ -701,3 +701,9 @@ md-tabs-canvas {
 .fc table {
   width: 99.9%
 }
+#announcement-banner {
+	font-weight: bold;
+    font-size: 1.1em;
+    margin-bottom: 0;
+    padding: 10px 15px;
+}

--- a/course_selection/templates/main/header.html
+++ b/course_selection/templates/main/header.html
@@ -1,4 +1,4 @@
-<div class="alert alert-warning fw-bold" role="alert">Creating alternate schedules will be removed at the end of 2022. Does your page look strange after adding an alternate schedule? Check out <a href="https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit?usp=sharing">this guide</a> for a fix!</div>
+<div id="announcement-banner" class="alert alert-warning fw-bold" role="alert">Creating alternate schedules will be removed at the end of 2022. Does your page look strange after adding an alternate schedule? Check out <a target="_blank" href="https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit?usp=sharing">this guide</a> for a fix!</div>
 <div id="header" class="group">
 <div id="header-inner" class="group">
     <div id="logo">

--- a/course_selection/templates/main/header.html
+++ b/course_selection/templates/main/header.html
@@ -1,4 +1,4 @@
-<div id="announcement-banner" class="alert alert-warning fw-bold" role="alert">Creating alternate schedules will be removed at the end of 2022. Does your page look strange after adding an alternate schedule? Check out <a target="_blank" href="https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit?usp=sharing">this guide</a> for a fix!</div>
+<div id="announcement-banner" class="alert alert-danger fw-bold" role="alert">Creating alternate schedules will be removed at the end of 2022. Does your page look strange after adding an alternate schedule? Check out <a target="_blank" href="https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit?usp=sharing">this guide</a> for a fix!</div>
 <div id="header" class="group">
 <div id="header-inner" class="group">
     <div id="logo">

--- a/course_selection/templates/main/header.html
+++ b/course_selection/templates/main/header.html
@@ -1,3 +1,4 @@
+<div class="alert alert-warning fw-bold" role="alert">Creating alternate schedules will be removed at the end of 2022. Does your page look strange after adding an alternate schedule? Check out <a href="https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit?usp=sharing">this guide</a> for a fix!</div>
 <div id="header" class="group">
 <div id="header-inner" class="group">
     <div id="logo">


### PR DESCRIPTION
A student emailed us and explained that adding an alternate schedule significantly screws up the UI, e.g. the entire search pane is missing. ReCal is so old that a fix is too difficult, so we'll remove the feature at the end of 2022. In the meantime, this PR puts up an announcement with a link to a "fix" document so that affected users can restore their functionality before the "Add a New Schedule" button is removed.

The fix doc is here: https://docs.google.com/document/d/1B4aOD6iUdxH7Oz6pFLinsDdjkSJ817szvU5ER1d1c5s/edit

<img width="2056" alt="CleanShot 2022-12-01 at 17 47 03@2x" src="https://user-images.githubusercontent.com/13815069/205175219-a17ff862-a3af-467b-8ea7-6d00fb963927.png">